### PR TITLE
:traffic_light: Migrate to docker/build-push-action@v2 using buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: docker/setup-buildx-action@v1
     - name: Ensure new image digest for final layer due to GitHub bug
       run: |
-        openssl rand -base64 64 -out cachebuster
+        openssl rand -out cachebuster -base64 64
         echo "COPY cachebuster ./" >> Dockerfile
     - name: Cache Docker layers
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,7 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
-        outputs: |
-          type=docker
-          type=registry
+        push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
-    - uses: docker/setup-buildx-action@v1
+    # - uses: docker/setup-buildx-action@v1
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,22 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
     - uses: docker/setup-buildx-action@v1
-#    - name: Cache Docker layers
-#      uses: actions/cache@v2
-#      with:
-#        path: /tmp/.buildx-cache
-#        key: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}-${{ github.sha }}
-#        restore-keys: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}
+    - name: Ensure new image digest for final layer due to GitHub bug
+      run: |
+        cat /dev/urandom | head -n 1 > cachebuster
+        echo "COPY cachebuster /dev/null" >> Dockerfile
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2
       with:
-#        cache-from: type=local,src=/tmp/.buildx-cache
-#        cache-to: type=local,dest=/tmp/.buildx-cache
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
         push: true
     - uses: shrink/actions-docker-extract@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         openssl rand -out cachebuster -base64 64
         echo "COPY cachebuster ./" >> Dockerfile
+        echo "!cachebuster" >> .dockerignore
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
-    # - uses: docker/setup-buildx-action@v1
+    - uses: docker/setup-buildx-action@v1
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:
@@ -27,8 +27,8 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+        load: true
         push: true
-        # outputs: type=image,dest=path
     - run: docker image ls
     - run: docker inspect ${{ steps.image.outputs.digest }}
     - run: docker inspect ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,19 +24,25 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: ${{ runner.os }}-buildx
     - name: Ensure new image digest for final layer due to GitHub bug
-      run: echo "ADD http://worldtimeapi.org/api/timezone/Europe/London.txt cachebuster" >> Dockerfile
+      run: echo "ADD https://worldtimeapi.org/api/ip.txt cachebuster" >> Dockerfile
     - id: push
       run: |
         echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
+        echo ::set-output name=at::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2
       with:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: |
-          ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
         push: true
+        tags: ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
+        labels: |
+          org.opencontainers.image.title=${{ github.repository }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          org.opencontainers.image.created=${{ steps.push.outputs.at }}
+          org.opencontainers.image.revision=${{ steps.push.outputs.sha }}
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Ensure new image digest for final layer due to GitHub bug
       run: |
         cat /dev/urandom | head -n 1 > cachebuster
-        echo "COPY cachebuster ." >> Dockerfile
+        echo "COPY cachebuster ./" >> Dockerfile
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,14 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
     - uses: docker/setup-buildx-action@v1
-    - name: Ensure new image digest for final layer due to GitHub bug
-      run: |
-        openssl rand -out cachebuster -base64 64
-        echo "COPY cachebuster ./" >> Dockerfile
-        echo "!cachebuster" >> .dockerignore
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: ${{ runner.os }}-buildx
+    - name: Ensure new image digest for final layer due to GitHub bug
+      run: echo "ADD http://worldtimeapi.org/api/timezone/Europe/London.txt cachebuster" >> Dockerfile
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build Application + Publish
 on: [push]
 
 env:
-  CACHE_ID: '000001'
+  CACHE_ID: '000002'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Application + Publish
+name: Build Application
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Ensure new image digest for final layer due to GitHub bug
       run: |
         cat /dev/urandom | head -n 1 > cachebuster
-        echo "COPY cachebuster /dev/null" >> Dockerfile
+        echo "COPY cachebuster ." >> Dockerfile
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: ${{ github.repository }}:${{ github.sha }}
+        tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
         push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
         restore-keys: ${{ runner.os }}-buildx
     - name: Ensure new image digest for final layer due to GitHub bug
       run: echo "ADD http://worldtimeapi.org/api/timezone/Europe/London.txt cachebuster" >> Dockerfile
-    - id: commit
+    - id: push
       run: |
         echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
-        echo ::set-output name=ref::${GITHUB_REF#refs/*/}
+        echo ::set-output name=ref::${${GITHUB_REF#refs/*/}//\//-}
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2
@@ -36,8 +36,8 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: |
-          ghcr.io/${{ github.repository }}:${{ steps.commit.outputs.sha }}
-          ghcr.io/${{ github.repository }}:${{ steps.commit.outputs.ref }}
+          ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
+          ghcr.io/${{ github.repository }}:${{ steps.push.outputs.ref }}
         push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build Application + Publish
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
 
 env:
   CACHE_ID: '000002'
@@ -17,8 +20,6 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
     - uses: docker/setup-buildx-action@v1
-      with:
-        buildkitd-flags: --debug
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:
-        image: ghcr.io/${{ github.repository }}:${{ github.sha }}
+        image: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
         path: /srv/artifacts/.
     - name: Upload Test Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,7 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
-        load: true
         push: true
-    - run: docker image ls
-    - run: docker inspect ${{ steps.image.outputs.digest }}
-    - run: docker inspect ghcr.io/${{ github.repository }}:${{ github.sha }}
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,19 @@ jobs:
         restore-keys: ${{ runner.os }}-buildx
     - name: Ensure new image digest for final layer due to GitHub bug
       run: echo "ADD http://worldtimeapi.org/api/timezone/Europe/London.txt cachebuster" >> Dockerfile
+    - id: commit
+      run: |
+        echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
+        echo ::set-output name=ref::${GITHUB_REF#refs/*/}
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2
       with:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ steps.commit.outputs.sha }}
+          ghcr.io/${{ github.repository }}:${{ steps.commit.outputs.ref }}
         push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         labels: |
           org.opencontainers.image.title=${{ github.repository }}
           org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          org.opencontainers.image.source=${{ github.event.repository.html_url }}
           org.opencontainers.image.created=${{ steps.push.outputs.at }}
           org.opencontainers.image.revision=${{ steps.push.outputs.sha }}
     - uses: shrink/actions-docker-extract@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,14 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
         push: true
+        # outputs: type=image,dest=path
+    - run: docker image ls
+    - run: docker inspect ${{ steps.image.outputs.digest }}
+    - run: docker inspect ghcr.io/${{ github.repository }}:${{ github.sha }}
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:
-        image: ${{ steps.image.outputs.digest }}
+        image: ghcr.io/${{ github.repository }}:${{ github.sha }}
         path: /srv/artifacts/.
     - name: Upload Test Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build Application + Publish
 
 on: [push]
 
+env:
+  CACHE_ID: '000001'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,8 +21,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx-
+        key: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:
-        image: ghcr.io/${{ github.repository }}:${{ steps.image.outputs.digest }}
+        image: ghcr.io/${{ github.repository }}@${{ steps.image.outputs.digest }}
         path: /srv/artifacts/.
     - name: Upload Test Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - '**'
 
-env:
-  CACHE_ID: '000002'
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,18 +17,18 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
     - uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}
+#    - name: Cache Docker layers
+#      uses: actions/cache@v2
+#      with:
+#        path: /tmp/.buildx-cache
+#        key: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}-${{ github.sha }}
+#        restore-keys: ${{ runner.os }}-buildx-${{ env.CACHE_ID }}
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2
       with:
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+#        cache-from: type=local,src=/tmp/.buildx-cache
+#        cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
         push: true
     - uses: shrink/actions-docker-extract@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:
-        image: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+        image: ghcr.io/${{ github.repository }}:${{ steps.image.outputs.digest }}
         path: /srv/artifacts/.
     - name: Upload Test Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
     - uses: docker/setup-buildx-action@v1
+      with:
+        buildkitd-flags: --debug
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
     - id: push
       run: |
         echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
-        echo ::set-output name=ref::${${GITHUB_REF#refs/*/}//\//-}
     - name: Build Image
       id: image
       uses: docker/build-push-action@v2
@@ -37,7 +36,6 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
         tags: |
           ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
-          ghcr.io/${{ github.repository }}:${{ steps.push.outputs.ref }}
         push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: docker/setup-buildx-action@v1
     - name: Ensure new image digest for final layer due to GitHub bug
       run: |
-        cat /dev/urandom | head -n 1 > cachebuster
+        openssl rand -base64 64 -out cachebuster
         echo "COPY cachebuster ./" >> Dockerfile
     - name: Cache Docker layers
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,10 @@ jobs:
       with:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: |
-          ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
-          ghcr.io/${{ github.repository }}:branch-test
-          ghcr.io/${{ github.repository }}:tag-test
-        push: true
+        tags: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+        outputs: |
+          type=docker
+          type=registry
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,10 @@ jobs:
       with:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-        tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+        tags: |
+          ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          ghcr.io/${{ github.repository }}:branch-test
+          ghcr.io/${{ github.repository }}:tag-test
         push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: Build Application + Publish
 
 on: [push]
 
@@ -7,25 +7,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Build & Publish If Tagged
-      uses: docker/build-push-action@v1
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
       with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT }}
         registry: ghcr.io
-        repository: ${{ github.repository }}
-        tag_with_ref: true
-        add_git_labels: true
-        push: ${{ startsWith(github.ref, 'refs/tags/') }}
-    - name: Get Latest Image
-      id: latest
-      uses: shrink/actions-docker-latest-image@v1
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
+    - uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
       with:
-        repository: ghcr.io/${{ github.repository }}
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx-
+    - name: Build Image
+      id: image
+      uses: docker/build-push-action@v2
+      with:
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
+        tags: ${{ github.repository }}:${{ github.sha }}
+        push: true
     - uses: shrink/actions-docker-extract@v1
       id: artifacts
       with:
-        image: ${{ steps.latest.outputs.image }}
+        image: ${{ steps.image.outputs.digest }}
         path: /srv/artifacts/.
     - name: Upload Test Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -28,4 +28,4 @@ jobs:
         curl -XPUT 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.ref }}' \
         -H 'content-type: application/vnd.docker.distribution.manifest.v2+json' \
         -H "Authorization: Bearer $GHCR_PAT" \
-        -d '@manifest-${{ steps.push.outputs.sha }}.json'
+        --data-binary '@manifest-${{ steps.push.outputs.sha }}.json'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,19 +13,13 @@ jobs:
       run: |
         echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
         echo ::set-output name=ref::${GITHUB_REF#refs/*/}
-    - name: Fetch manifest for commit image
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT_BASE64 }}
-      run: |
-        curl 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.sha }}' \
-        -H 'accept: application/vnd.docker.distribution.manifest.v2+json' \
-        -H "Authorization: Bearer $GHCR_PAT" \
-        -o manifest-${{ steps.push.outputs.sha }}.json
-    - name: Push new tag for manifest
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT_BASE64 }}
-      run: |
-        curl -XPUT 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.ref }}' \
-        -H 'content-type: application/vnd.docker.distribution.manifest.v2+json' \
-        -H "Authorization: Bearer $GHCR_PAT" \
-        --data-binary '@manifest-${{ steps.push.outputs.sha }}.json'
+    - name: Publish Tag
+      uses: shrink/actions-docker-registry-tag@v1
+      with:
+        registry: ghcr.io
+        token: ${{ secrets.GHCR_PAT }}
+        repository: ${{ github.repository }}
+        target: sha-${{ github.sha }}
+        tags: |
+          ${{ steps.push.outputs.ref }}
+          latest

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,29 @@
+name: Tag Application Build
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
+    - id: push
+      run: |
+        echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
+        echo ::set-output name=ref::${GITHUB_REF#refs/*/}
+    - name: Publish image for tag
+      run: |
+        REPOSITORY=ghcr.io/${{ github.repository }}
+        COMMIT=${REPOSITORY}:${{ steps.push.outputs.sha }}
+        TAG=${REPOSITORY}:${{ steps.push.outputs.ref }}
+        docker pull ${COMMIT}
+        docker tag ${COMMIT} ${TAG}
+        docker push ${TAG}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,7 @@ jobs:
         curl 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.sha }}' \
         -H 'accept: application/vnd.docker.distribution.manifest.v2+json' \
         -H "Authorization: Bearer $GHCR_PAT" \
-        > manifest-${{ steps.push.outputs.sha }}.json
+        -o manifest-${{ steps.push.outputs.sha }}.json
     - name: Push new tag for manifest
       env:
         GHCR_PAT: ${{ secrets.GHCR_PAT_BASE64 }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,11 +19,19 @@ jobs:
       run: |
         echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
         echo ::set-output name=ref::${GITHUB_REF#refs/*/}
-    - name: Publish image for tag
+    - name: Fetch manifest for commit image
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT_BASE64 }}
       run: |
-        REPOSITORY=ghcr.io/${{ github.repository }}
-        COMMIT=${REPOSITORY}:${{ steps.push.outputs.sha }}
-        TAG=${REPOSITORY}:${{ steps.push.outputs.ref }}
-        docker pull ${COMMIT}
-        docker tag ${COMMIT} ${TAG}
-        docker push ${TAG}
+        curl 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.sha }}' \
+        -H 'accept: application/vnd.docker.distribution.manifest.v2+json' \
+        -H "Authorization: Bearer $GHCR_PAT" \
+        > manifest-${{ steps.push.outputs.sha }}.json
+    - name: Push new tag for manifest
+      env:
+        GHCR_PAT_SECRET: ${{ secrets.GHCR_PAT_BASE64 }}
+      run: |
+        curl -XPUT 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.ref }}' \
+        -H 'content-type: application/vnd.docker.distribution.manifest.v2+json' \
+        -H "Authorization: Bearer $GHCR_PAT" \
+        -d '@manifest-${{ steps.push.outputs.sha }}.json'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
         registry: ghcr.io
         token: ${{ secrets.GHCR_PAT }}
         repository: ${{ github.repository }}
-        target: sha-${{ github.sha }}
+        target: ${{ steps.push.outputs.sha }}
         tags: |
           ${{ steps.push.outputs.ref }}
           latest

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,12 +9,6 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_PAT }}
     - id: push
       run: |
         echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
@@ -29,7 +23,7 @@ jobs:
         > manifest-${{ steps.push.outputs.sha }}.json
     - name: Push new tag for manifest
       env:
-        GHCR_PAT_SECRET: ${{ secrets.GHCR_PAT_BASE64 }}
+        GHCR_PAT: ${{ secrets.GHCR_PAT_BASE64 }}
       run: |
         curl -XPUT 'https://ghcr.io/v2/${{ github.repository }}/manifests/${{ steps.push.outputs.ref }}' \
         -H 'content-type: application/vnd.docker.distribution.manifest.v2+json' \


### PR DESCRIPTION
Closes #29

Migrates from docker/build-push-action@v1 to v2 which uses buildx, which alongside the addition of caching will reduce build time significantly. Added [`shrink/actions-docker-registry-tag`](https://github.com/marketplace/actions/docker-registry-tag) for efficient release tagging.

- [x] Upgrade from v1 to v2
- [x] Cache build result
- [x] Tag image with commit
- [x] Tag image with git tag