### PR TITLE
ci: Secure GitHub Actions with separate write step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       can-write: steps.check.outputs.has-permission
     steps:
       - id: check
-        uses: scherermichael-oss/action-has-permission@master
+        uses: scherermichael-oss/action-has-permission@1.0.6
         with:
           required-permission: write
   push:
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    if: needs.permissions.outputs.can-write == 'true'
+    if: needs.permissions.outputs.can-write
     steps:
       - name: Download application's Docker image from build job
         uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,63 +3,87 @@ name: Build Application
 on:
   push:
     branches:
-      - '**'
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
-  build:
+  image:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_PAT }}
-    - uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx
-    - name: Ensure new image digest for final layer due to GitHub bug
-      run: echo "ADD https://worldtimeapi.org/api/ip.txt cachebuster" >> Dockerfile
-    - id: push
-      run: |
-        echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
-        echo ::set-output name=at::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-    - name: Build Image
-      uses: docker/build-push-action@v2
-      with:
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
-        push: true
-        tags: ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
-        labels: |
-          org.opencontainers.image.title=${{ github.repository }}
-          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.html_url }}
-          org.opencontainers.image.created=${{ steps.push.outputs.at }}
-          org.opencontainers.image.revision=${{ steps.push.outputs.sha }}
-    - name: Re-run failed build for test report extraction (using `test` stage)
-      if: ${{ failure() }}
-      uses: docker/build-push-action@v2
-      with:
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
-        load: true
-        tags: ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
-        target: test
-    - uses: shrink/actions-docker-extract@v1
-      if: ${{ always() }}
-      id: artifacts
-      with:
-        image: ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}
-        path: /srv/artifacts/.
-    - name: Upload Test Reports
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v2
-      with:
-        path: ${{ steps.artifacts.outputs.destination }}
-        name: 'test-reports'
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+      - name: Build application image
+        uses: docker/build-push-action@v2
+        with:
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Re-run failed build to `test` stage for subsequent report extraction
+        if: failure()
+        uses: docker/build-push-action@v2
+        with:
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          target: test
+      - name: Extract test report(s) from all image builds
+        uses: shrink/actions-docker-extract@v1
+        if: always()
+        id: artifacts
+        with:
+          image: ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          path: /srv/artifacts/.
+      - name: Upload test report(s) as pipeline artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ steps.artifacts.outputs.destination }}
+          name: "test-reports"
+      - if: success()
+        run: docker save --output app.tar ${{ env.IMAGE }}
+      - name: Upload application's Docker image as pipeline artifact
+        if: success()
+        uses: actions/upload-artifact@v2
+        with:
+          path: app.tar
+          name: app.tar
+  permissions:
+    runs-on: ubuntu-latest
+    outputs:
+      can-write: ${{ steps.permission.outputs.result }}
+    steps:
+      - id: permission
+        uses: actions-cool/check-user-permission@v1.0.0
+        with:
+          require: write
+  push:
+    needs: [image, actor]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    if: needs.permissions.outputs.can-write == 'true'
+    steps:
+      - name: Download application's Docker image from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: app.tar
+      - name: Log in to GitHub Container Registry as actor
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: docker load --input app.tar
+      - name: Push image to Container Registry for all tags
+        run: docker image push --all-tags ${{ env.IMAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
       - run: docker load --input app.tar
       - name: Push image to Container Registry for all tags
         run: docker image push --all-tags ${{ env.IMAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           require: write
   push:
-    needs: [image, actor]
+    needs: [image, permissions]
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,12 @@ jobs:
   permissions:
     runs-on: ubuntu-latest
     outputs:
-      can-write: ${{ steps.permission.outputs.result }}
+      can-write: steps.check.outputs.has-permission
     steps:
-      - id: permission
-        uses: actions-cool/check-user-permission@v1.0.0
+      - id: check
+        uses: scherermichael-oss/action-has-permission@master
         with:
-          require: write
+          required-permission: write
   push:
     needs: [image, permissions]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,8 @@
 name: Build Application
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
-    branches:
-      - "**"
+    types: [opened, synchronize, closed, reopened]
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
Addresses #48

The current workflows were written without considering the security implications, however GitHub are now introducing more security by default which means that people who don't consider the security implications are protected from their mistakes: therefore... these workflows no longer work.

This updated workflow separates out the _safe_ build job (which can be run for all Pull Requests without concern) from the _unsafe_ push job (which requires write permissions) so that we can provide meaningful build status reports on Pull Requests and continue to enable easy pushing of builds to the GitHub Container Registry.

- [x] Application is built and test report artifacts are extracted as part of the same **unprivileged** job
- [x] Build workflow runs on all branches and pull requests
- [x] Docker image is pushed to registry when actor has write permissions
- [x] Docker image is tagged with short (`sha-xxxxxxxx`) and branch name