### PR TITLE
ci: Push Docker image to registry using privileged workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,85 +1,58 @@
-name: Build Application
+name: Build Application Image
 
 on:
-  pull_request:
-    types: [opened, synchronize, closed, reopened]
+  push:
+    branches:
+      - "**"
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}
+  IMAGE: "ghcr.io/${{ github.repository }}"
 
 jobs:
-  image:
+  build-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - id: meta
+      - name: Generate branch Docker Image attributes
+        id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
-          images: ${{ env.IMAGE }}
+          images: "${{ env.IMAGE }}"
           tags: |
             type=ref,event=branch
             type=sha
-      - name: Build application image
+      - name: Build Docker Image
+        id: build
         uses: docker/build-push-action@v2
         with:
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Re-run failed build to `test` stage for subsequent report extraction
-        if: failure()
-        uses: docker/build-push-action@v2
-        with:
-          load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          target: test
-      - name: Extract test report(s) from all image builds
-        uses: shrink/actions-docker-extract@v1
-        if: always()
-        id: artifacts
-        with:
-          image: ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
-          path: /srv/artifacts/.
-      - name: Upload test report(s) as pipeline artifacts
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          path: ${{ steps.artifacts.outputs.destination }}
-          name: "test-reports"
-      - if: success()
-        run: docker save --output app.tar ${{ env.IMAGE }}
-      - name: Upload application's Docker image as pipeline artifact
-        if: success()
+          tags: "${{ steps.meta.outputs.tags }}"
+          labels: "${{ steps.meta.outputs.labels }}"
+      - name: Save Docker Image archive to local filesystem
+        run: "docker save --output app.tar ${{ env.IMAGE }}"
+      - name: Upload application's Docker Image as pipeline artifact
         uses: actions/upload-artifact@v2
         with:
           path: app.tar
           name: app.tar
-  permissions:
-    runs-on: ubuntu-latest
-    outputs:
-      can-write: steps.check.outputs.has-permission
-    steps:
-      - id: check
-        uses: scherermichael-oss/action-has-permission@1.0.6
+      - name: "Re-run failed build to `test` stage"
+        if: failure()
+        uses: docker/build-push-action@v2
         with:
-          required-permission: write
-  push:
-    needs: [image, permissions]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    if: needs.permissions.outputs.can-write
-    steps:
-      - name: Download application's Docker image from build job
-        uses: actions/download-artifact@v2
+          target: test
+          load: true
+          tags: "${{ steps.meta.outputs.tags }}"
+      - name: Extract test reports from Docker Image
+        if: always()
+        uses: shrink/actions-docker-extract@v1
+        id: reports
         with:
-          name: app.tar
-      - name: Log in to GitHub Container Registry as actor
-        uses: docker/login-action@v1
+          image: "${{ env.IMAGE }}:${{ steps.meta.outputs.version }}"
+          path: /srv/reports/.
+      - name: Upload test report(s) as pipeline artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
-      - run: docker load --input app.tar
-      - name: Push image to Container Registry for all tags
-        run: docker image push --all-tags ${{ env.IMAGE }}
+          path: "${{ steps.reports.outputs.destination }}"
+          name: test-reports

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,28 @@
+name: Push Application Image To Registry
+
+on:
+  workflow_run:
+    workflows:
+      - Build Application Image
+    types:
+      - completed
+
+jobs:
+  push-image-on-success:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download application's Docker Image from build workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build.yml
+          name: app.tar
+      - name: Log in to GitHub Container Registry as actor
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
+      - run: docker load --input app.tar
+      - name: Push Docker Image to Container Registry for all tags
+        run: "docker image push --all-tags ghcr.io/${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,11 @@ name: Upload Release Assets
 
 on:
   release:
-    types: [created]
+    types:
+      - created
 
 jobs:
-  assets:
+  upload-release-assets:
     runs-on: ubuntu-latest
     steps:
     - name: Get Release
@@ -17,38 +18,39 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_PAT }}
-    - name: Extract Test Artifacts
+        username: "${{ github.repository_owner }}"
+        password: "${{ secrets.GHCR_PAT }}"
+    - name: Extract Test Reports
       uses: shrink/actions-docker-extract@v1
-      id: artifacts
+      id: reports
       with:
-        image: ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}
-        path: /srv/artifacts/.
-    - name: Compress Test Artifacts
+        image: "ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}"
+        path: /srv/reports/.
+    - name: Compress Test Reports
       uses: papeloto/action-zip@v1
       with:
-        files: ${{ steps.artifacts.outputs.destination }}
-        dest: test-artifacts.zip
-    - name: Upload Test Artifacts
+        files: "${{ steps.reports.outputs.destination }}"
+        dest: test-reports.zip
+    - name: Upload Test Reports
       uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: test-artifacts.zip
-        asset_name: ${{ steps.release.outputs.tag_name }}-test-artifacts.zip
-        asset_content_type: application/zip
       env:
         GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: "${{ steps.release.outputs.upload_url }}"
+        asset_path: test-reports.zip
+        asset_name: "${{ steps.release.outputs.tag_name }}-test-reports.zip"
+        asset_content_type: application/zip
     - name: Save Application Image
       run: |
         docker save --output ${{ steps.release.outputs.tag_name }}.tar \
         ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}
     - name: Upload Application Image
       uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: ${{ steps.release.outputs.tag_name }}.tar
-        asset_name: ${{ steps.release.outputs.tag_name }}-app.tar
-        asset_content_type: application/x-tar
       env:
         GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: "${{ steps.release.outputs.upload_url }}"
+        asset_path: "${{ steps.release.outputs.tag_name }}.tar"
+        asset_name: "${{ steps.release.outputs.tag_name }}-app.tar"
+        asset_content_type: application/x-tar
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,48 +9,47 @@ jobs:
   upload-release-assets:
     runs-on: ubuntu-latest
     steps:
-    - name: Get Release
-      id: release
-      uses: bruceadams/get-release@v1.2.1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: "${{ github.repository_owner }}"
-        password: "${{ secrets.GHCR_PAT }}"
-    - name: Extract Test Reports
-      uses: shrink/actions-docker-extract@v1
-      id: reports
-      with:
-        image: "ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}"
-        path: /srv/reports/.
-    - name: Compress Test Reports
-      uses: papeloto/action-zip@v1
-      with:
-        files: "${{ steps.reports.outputs.destination }}"
-        dest: test-reports.zip
-    - name: Upload Test Reports
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: "${{ steps.release.outputs.upload_url }}"
-        asset_path: test-reports.zip
-        asset_name: "${{ steps.release.outputs.tag_name }}-test-reports.zip"
-        asset_content_type: application/zip
-    - name: Save Application Image
-      run: |
-        docker save --output ${{ steps.release.outputs.tag_name }}.tar \
-        ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}
-    - name: Upload Application Image
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: "${{ steps.release.outputs.upload_url }}"
-        asset_path: "${{ steps.release.outputs.tag_name }}.tar"
-        asset_name: "${{ steps.release.outputs.tag_name }}-app.tar"
-        asset_content_type: application/x-tar
-
+      - name: Get Release
+        id: release
+        uses: bruceadams/get-release@v1.2.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GHCR_PAT }}"
+      - name: Extract Test Reports
+        uses: shrink/actions-docker-extract@v1
+        id: reports
+        with:
+          image: "ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}"
+          path: /srv/reports/.
+      - name: Compress Test Reports
+        uses: papeloto/action-zip@v1
+        with:
+          files: "${{ steps.reports.outputs.destination }}"
+          dest: test-reports.zip
+      - name: Upload Test Reports
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: "${{ steps.release.outputs.upload_url }}"
+          asset_path: test-reports.zip
+          asset_name: "${{ steps.release.outputs.tag_name }}-test-reports.zip"
+          asset_content_type: application/zip
+      - name: Save Application Image
+        run: |
+          docker save --output ${{ steps.release.outputs.tag_name }}.tar \
+          ghcr.io/${{ github.repository }}:${{ steps.release.outputs.tag_name }}
+      - name: Upload Application Image
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: "${{ steps.release.outputs.upload_url }}"
+          asset_path: "${{ steps.release.outputs.tag_name }}.tar"
+          asset_name: "${{ steps.release.outputs.tag_name }}-app.tar"
+          asset_content_type: application/x-tar

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,21 +3,21 @@ name: Tag Application Build
 on:
   push:
     tags:
-      - '**'
+      - "**"
 
 jobs:
-  tag:
+  add-version-tag:
     runs-on: ubuntu-latest
     steps:
-    - id: push
-      run: |
-        echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
-        echo ::set-output name=ref::${GITHUB_REF#refs/*/}
-    - name: Publish Tag
-      uses: shrink/actions-docker-registry-tag@v1
-      with:
-        registry: ghcr.io
-        token: ${{ secrets.GHCR_PAT }}
-        repository: ${{ github.repository }}
-        target: ${{ steps.push.outputs.sha }}
-        tags: ${{ steps.push.outputs.ref }}
+      - id: short
+        uses: benjlevesque/short-sha@v1.2
+      - id: version
+        uses: battila7/get-version-action@v2
+      - name: Add version tag to commit build
+        uses: shrink/actions-docker-registry-tag@v1
+        with:
+          registry: ghcr.io
+          token: "${{ secrets.GHCR_PAT }}"
+          repository: "${{ github.repository }}"
+          target: "sha-${{ steps.short.outputs.sha }}"
+          tags: "${{ steps.version.outputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /vendor/**
 /.env
 /.phpunit.result.cache
-/artifacts/**
+/reports/**
 /junit.xml
 /docker-compose.override.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN composer dump-autoload --optimize
 
 FROM php
 COPY --chown=nobody . ./
-COPY --from=validate /srv/artifacts /srv/artifacts
+COPY --from=validate /srv/reports /srv/reports
 COPY --from=production /srv/vendor /srv/vendor
 
 HEALTHCHECK --interval=10s --timeout=1s --retries=3 \

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
       "vendor/bin/phpcs --standard=PSR12 src/"
     ],
     "static": [
-      "vendor/bin/psalm --long-progress --report=artifacts/psalm.junit.xml"
+      "vendor/bin/psalm --long-progress --report=reports/psalm.junit.xml"
     ]
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,7 +28,7 @@
     <extension class="Tests\App\Bootstrap"/>
   </extensions>
   <logging>
-    <junit outputFile="artifacts/phpunit.junit.xml"/>
+    <junit outputFile="reports/phpunit.junit.xml"/>
   </logging>
   <php>
     <server name="APP_ENV" value="testing"/>


### PR DESCRIPTION
Closes #53

The current homegrown `permissions` and `push` jobs introduced in #49 are a workaround for allowing jobs to run for unprivileged users, however there's a [`workflow_run`][actions:workflow_run] feature that enables secure execution of privileged workflow.

- [x] Rename test reports in pipeline from `artifacts` to `reports`
- [x] Securely push new image for commits on each branch to registry using `push` job running on `main` branch
- [x] Replace use of `run` in `tag` workflow with actions

[actions:workflow_run]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run